### PR TITLE
Some code improvements

### DIFF
--- a/examples/PASTA/README.md
+++ b/examples/PASTA/README.md
@@ -3,7 +3,7 @@ Its home is at: https://github.com/PASTA-ELN
 
 ### PASTA.eln
 ```
-ro-crate-metadata.json
+ ro-crate-metadata.json
   publisher: PASTA ELN
   version: 1.0
 ./

--- a/tools/eln2md.py
+++ b/tools/eln2md.py
@@ -1,75 +1,86 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os, shutil, json, sys
 from zipfile import ZipFile, ZIP_DEFLATED
 
 
 def simplify(metadata):
-  """
-  simplify metadata by removing everything except @id, @type, hasPart
-  """
-  for item in metadata['@graph']:
-    if item['@id'] in ['ro-crate-metadata.json','./']:
-      continue
-    for subitem in [i for  i in item]:
-      if subitem not in ['@id','@type','hasPart']:
-        del item[subitem]
-  return json.dumps(metadata, indent=2)
+    """
+    simplify metadata by removing everything except @id, @type, hasPart
+    """
+    for item in metadata['@graph']:
+        if item['@id'] in ['ro-crate-metadata.json', './']:
+            continue
+        for subitem in [i for i in item]:
+            if subitem not in ['@id', '@type', 'hasPart']:
+                del item[subitem]
+    return json.dumps(metadata, indent=2)
 
 
 def tree(metadata):
-  def processPart(part, level):
-    """
-    recursive function call to process this node
-    """
-    prefix = '    '*(level-1)+'|-> '
-    output = prefix+part['@id']
-    # find next node to process
-    newNode = [i for i in metadata['@graph'] if '@id' in i and i['@id']==part['@id']]
-    if len(newNode)==1:
-      output += ',  items: '+str(len(newNode[0])-1)+' \n'  #-1 because @id is not counted
-      subparts = newNode[0].pop('hasPart') if 'hasPart' in newNode[0] else []
-      if len(subparts)>0:  #don't do if no subparts: measurements, ...
-        for subpart in subparts:
-          output += processPart(subpart, level+1)
-    else:
-      output += ',  items: '+str(len(part)-1)+'\n'  #-1 because @id is not counted
+    def processPart(part, level):
+        """
+        recursive function call to process this node
+        """
+        prefix = '    ' * (level - 1) + '|-> '
+        output = prefix + part['@id']
+        # find next node to process
+        newNode = [
+            i for i in metadata['@graph'] if '@id' in i and i['@id'] == part['@id']
+        ]
+        if len(newNode) == 1:
+            output += (
+                ',  items: ' + str(len(newNode[0]) - 1) + ' \n'
+            )  # -1 because @id is not counted
+            subparts = newNode[0].pop('hasPart') if 'hasPart' in newNode[0] else []
+            if len(subparts) > 0:  # don't do if no subparts: measurements, ...
+                for subpart in subparts:
+                    output += processPart(subpart, level + 1)
+        else:
+            output += (
+                ',  items: ' + str(len(part) - 1) + '\n'
+            )  # -1 because @id is not counted
+        return output
+
+    # main tree-function
+    graph = metadata["@graph"]
+    # find information from master node
+    rocrateNode = [i for i in graph if i["@id"] == "ro-crate-metadata.json"][0]
+    output = 'ro-crate-metadata.json\n'
+    if 'sdPublisher' in rocrateNode:
+        output += '  publisher: ' + rocrateNode['sdPublisher']['name'] + '\n'
+    if 'version' in rocrateNode:
+        output += '  version: ' + rocrateNode['version'] + '\n'
+    mainNode = [i for i in graph if i["@id"] == "./"][0]
+    output += './\n'
+    # iteratively go through list
+    for part in mainNode['hasPart']:
+        output += processPart(
+            part, 1
+        )  # TODO_P2 first child should get elnName and version
     return output
-  #main tree-function
-  graph = metadata["@graph"]
-  #find information from master node
-  rocrateNode = [i for i in graph if i["@id"]=="ro-crate-metadata.json"][0]
-  output = 'ro-crate-metadata.json\n'
-  if 'sdPublisher' in rocrateNode:
-    output += '  publisher: '+rocrateNode['sdPublisher']['name']+'\n'
-  if 'version' in rocrateNode:
-    output += '  version: '+rocrateNode['version']+'\n'
-  mainNode    = [i for i in graph if i["@id"]=="./"][0]
-  output += './\n'
-  #iteratively go through list
-  for part in mainNode['hasPart']:
-    output += processPart(part, 1) #TODO_P2 first child should get elnName and version
-  return output
 
 
 if __name__ == '__main__':
-  #prepare README.md file
-  if os.path.exists('README_template.md'):
-    shutil.copy('README_template.md','README.md')
-  outfile = open('README.md','a')
+    # prepare README.md file
+    if os.path.exists('README_template.md'):
+        shutil.copy('README_template.md', 'README.md')
+    outfile = open('README.md', 'a')
 
-  for fileName in os.listdir('.'):
-    if fileName.endswith('.eln'):
-      outfile.write('\n### '+fileName+'\n')
-      with ZipFile(fileName, 'r', compression=ZIP_DEFLATED) as elnFile:
-        files = elnFile.namelist()
-        dirName=files[0].split(os.sep)[0]
-        if dirName+'/ro-crate-metadata.json' in files:
-          metadata = json.loads(elnFile.read(dirName+'/ro-crate-metadata.json'))
-          if len(sys.argv)>1 and sys.argv[1]=='simple':
-            output = simplify(metadata)
-          elif len(sys.argv)>1 and sys.argv[1]=='tree':
-            output = tree(metadata)
-          else:
-            output = json.dumps(metadata, indent=2)
-          outfile.write('```\n'+output+'\n```\n\n')
-  outfile.close()
+    for fileName in os.listdir('.'):
+        if fileName.endswith('.eln'):
+            outfile.write('\n### ' + fileName + '\n')
+            with ZipFile(fileName, 'r', compression=ZIP_DEFLATED) as elnFile:
+                files = elnFile.namelist()
+                dirName = files[0].split(os.sep)[0]
+                if dirName + '/ro-crate-metadata.json' in files:
+                    metadata = json.loads(
+                        elnFile.read(dirName + '/ro-crate-metadata.json')
+                    )
+                    if len(sys.argv) > 1 and sys.argv[1] == 'simple':
+                        output = simplify(metadata)
+                    elif len(sys.argv) > 1 and sys.argv[1] == 'tree':
+                        output = tree(metadata)
+                    else:
+                        output = json.dumps(metadata, indent=2)
+                    outfile.write('```\n' + output + '\n```\n\n')
+    outfile.close()


### PR DESCRIPTION
First commit is just formatting (with `black --skip-string-normalization tools/eln2md.py`) and using `/usr/bin/env` for the shebang.

Second commit is:

* use constants for filenames
* use isort for import statements formatting
* use Pathlib instead of os
* fix bug where content was appended to previous file if no templates
  were found
* remove extra newline at end of generated file