### PR TITLE
Adding NOMAD .eln support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ Generally working with some quirks here and there.
 | [Pasta](https://github.com/PASTA-ELN/pasta-eln)   | ✅ | ✅ | [PASTA](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/PASTA)       |
 | [SampleDB](https://github.com/sciapp/sampledb)    | ✅ | ✅ | [SampleDB](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/SampleDB) |
 | [Rspace](https://www.researchspace.com/)          | ✅ | ✅ | [RSpace](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/RSpace)     |
+| [NOMAD](https://nomad-lab.eu)                     | ✅ |    | |
 
+ 


### PR DESCRIPTION
Dear @NicolasCARPi and all the other contributors. 

Since NOMAD does import .eln files and @amirgolp demonstrated this on the last elabFTW users meeting, I thought we should add NOMAD to the list of tools supporting the format. I only put input, since we only see NOMAD ad a consumer of .eln files and a potential data publishing platform for .eln file users. I think example does not apply, when you are importing files. Just listing an elabFTW file for example, seems wrong to me.