### PR TITLE
spec: use string type for `@type` value of root data entity

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -89,7 +89,7 @@ The second node is basically describing the current directory (`./`).
 ```json
 {
   "@id": "./",
-  "@type": ["Dataset"],
+  "@type": "Dataset",
   "hasPart": [
     {
       "@id": "./2022-05-29 - Some-experiment/"


### PR DESCRIPTION
@type: MUST be Dataset
https://www.researchobject.org/ro-crate/specification/1.1/root-data-entity.html