### PR TITLE
Added LinkAhead support for .eln import to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Generally working with some quirks here and there.
 | [Pasta](https://github.com/PASTA-ELN/pasta-eln)   | ✅ | ✅ | [PASTA](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/PASTA)       |
 | [SampleDB](https://github.com/sciapp/sampledb)    | ✅ | ✅ | [SampleDB](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/SampleDB) |
 | [Rspace](https://www.researchspace.com/)          | ✅ | ✅ | [RSpace](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/RSpace)     |
-| [NOMAD](https://nomad-lab.eu)                     | ✅ |    | |
+| [NOMAD](https://nomad-lab.eu)                     | ✅ |   |     |
+| [LinkAhead](https://getlinkahead.com/)            | ✅ |   |     |
 
  


### PR DESCRIPTION
Support for crawling ELN Files (and ROCrates) using the [LinkAhead Crawler](https://gitlab.com/linkahead/linkahead-crawler) was added in release 0.10.0, see:

https://gitlab.com/linkahead/linkahead-crawler/-/commit/921f01375efb7776e2a620a76e69775e72d05c42#ab09011fa121d0a2bb9fa4ca76094f2482b902b7_8_22

It still really fresh, so the documentation for this feature is still work-in-progress. However, there are some unit tests with examples on how to use it here: https://gitlab.com/linkahead/linkahead-crawler/-/blob/main/unittests/test_rocrate_converter.py?ref_type=heads

(Btw.: I implemented some workarounds for some of the open issues discussed recently. I will deprecate and remove them as soon as the issues are completed.)