### PR TITLE
fix: allow @type be of type array

### DIFF
--- a/tests/schema.json
+++ b/tests/schema.json
@@ -15,7 +15,17 @@
             "type": "string"
           },
           "@type": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           },
           "about": {
             "type": "object",


### PR DESCRIPTION
@SteffenBrinckmann 
see https://www.researchobject.org/ro-crate/specification/1.1/data-entities.html#referencing-files-and-folders-from-the-root-data-entity