### PR TITLE
chore: update SciLog as supporting import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Generally working with some quirks here and there.
 | [NOMAD](https://nomad-lab.eu)                             | ✅          |             |                                                                                                              |
 | [LinkAhead](https://getlinkahead.com/)                    | ✅          |             |                                                                                                              |
 | [OpenSemanticLab](https://github.com/OpenSemanticLab)     | ✅          | ✅          | [OpenSemanticLab](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/OpenSemanticLab) |
-| [SciLog](https://github.com/paulscherrerinstitute/scilog) |             | ✅          | [SciLog](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/SciLog)                   |
+| [SciLog](https://github.com/paulscherrerinstitute/scilog) |✅            | ✅          | [SciLog](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/SciLog)                   |
 | [datalab](https://github.com/datalab-org)                 |             | ✅          | [datalab](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/datalab)                 |
 

--- a/examples/SciLog/README.md
+++ b/examples/SciLog/README.md
@@ -2,7 +2,8 @@
 
 [Homepage](https://www.psi.ch/en/awi/scilog) | [Docs](https://paulscherrerinstitute.github.io/scilog/) | [Code](https://github.com/paulscherrerinstitute/scilog)
 
-SciLog allows users to export logbooks in the [ELN File format](https://github.com/TheELNConsortium/TheELNFileFormat/blob/master/SPECIFICATION.md) (support for ELN import is work-in-progress). 
+SciLog allows users to export logbooks in the [ELN File format](https://github.com/TheELNConsortium/TheELNFileFormat/blob/master/SPECIFICATION.md).
+ELNs exported from SciLog can also be imported back into SciLog ([docs](https://paulscherrerinstitute.github.io/scilog/Users/Dashboard.html#importing-from-an-eln-archive)).
 While the overall implementation is similar to other ELN implementations (e.g. the ELN is a zipped RO-Crate with .eln extension), it has the following pecularities
 - Instead of using the `genre` property (e.g. like elabFTW) to distinguish between ELN concepts, SciLog uses more specific scehma.org types in addition to `Dataset` (e.g. Book, Message, etc), 
 - Hence, entities may have multiple `@type`s e.g. `[Book, Dataset]`


### PR DESCRIPTION
Thanks to @pozsa for implementing ELN import feature in SciLog. Updating README in this PR.

<img width="493" height="593" alt="Screenshot from 2026-07-09 15-04-34" src="https://github.com/user-attachments/assets/144cf41a-848e-4242-89fd-ec062dbbf3b1" />