### PR TITLE
Clarify @type, additionalType, and genre

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -123,6 +123,9 @@ For instance, a "comment" on an experiment will exist as a `@type: Comment` node
 
 #### Specific fields
 
+* [`@type`](https://www.w3.org/TR/json-ld11/#specifying-the-type): use this field for the Schema.org and RO-Crate types of a node. Directory data entities MUST include `Dataset`, and files MUST include `File`. A node MAY have more than one type, represented as an array, when another Schema.org type provides useful detail (for example, `["Dataset", "Message"]`).
+* [`additionalType`](https://schema.org/additionalType): use this field for more specific types from external vocabularies. Prefer an IRI, or an array of IRIs when several types apply. The .eln file format does not prescribe a particular external vocabulary.
+* [`genre`](https://schema.org/genre): use this field for a broad, human-readable category, such as `experiment`. In an .eln file it is a string, not an alias for `@type`; use `additionalType` instead when the value identifies a class in an external vocabulary.
 * `contentSize`: this term is loosely defined by Schema.org. In a .eln it is a string with the number of bytes. See "Example File" section below. It contains no units.
 * `variableMeasured`: this term is interpreted more loosely for .eln files than by Schema.org, as consisting of `@type: PropertyValue` nodes that represent not just variables measured, but also variables specified for a `@type: Dataset` node (e.g. flexible metadata).
   * The `identifier` for a `@type: PropertyValue` node can be set to an IRI (e.g. the URL for an ontology entry, such as http://purl.org/dc/terms/instructionalMethod) for specifying the meaning of this node.


### PR DESCRIPTION
## Summary

- clarify that `@type` carries Schema.org/RO-Crate structural types and may be an array
- direct external-vocabulary classifications to `additionalType` without prescribing an ontology
- define `genre` as a human-readable string rather than an alias for `@type`

This documents the field roles agreed in the discussion and matches the repository's current support for multiple `@type` values.

Closes #105.

## Validation

- `python -m pytest --tb=short -s` (5 passed)
- `sphinx-build -M html docs/source <build-dir> --fail-on-warning`
- rendered `SPECIFICATION.md` with Markdown-It and verified the three reference links
