### PR TITLE
Validate array-valued Dataset and File nodes

### DIFF
--- a/tests/checks.py
+++ b/tests/checks.py
@@ -76,7 +76,12 @@ def checkParamMetadataJson(fileName):
         if '@type' not in node:
             print('**ERROR: all nodes must have @type. check:', nodeID)
             return False
-        if node['@type'] == 'Dataset':
+        node_types = node['@type']
+        if isinstance(node_types, str):
+            node_types = [node_types]
+        elif not isinstance(node_types, list):
+            node_types = []
+        if 'Dataset' in node_types:
             for key in DATASET_MANDATORY:
                 if key not in node:
                     print(f'**ERROR in dataset: "{key}" not in @id={node["@id"]}')
@@ -84,7 +89,7 @@ def checkParamMetadataJson(fileName):
             for key in DATASET_SUGGESTED:
                 if key not in node and OUTPUT_INFO:
                     print(f'**INFO for dataset: "{key}" not in @id={node["@id"]}')
-        elif node['@type'] == 'File':
+        elif 'File' in node_types:
             for key in FILE_MANDATORY:
                 if key not in node:
                     print(f'**ERROR in file: "{key}" not in @id={node["@id"]}')

--- a/tests/test_01_params_metadata_json.py
+++ b/tests/test_01_params_metadata_json.py
@@ -1,8 +1,40 @@
 #!/usr/bin/python3
 """  This tests against rules that we as the ELN consortium set for ourselves """
+import json
+import tempfile
 import unittest
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
 from checks import checkParamMetadataJson
 from test_00_pypi_rocrate import generalizedTest
+
+
+def write_test_eln(path, entity_id, entity_type):
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": "./"},
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+                "version": "1.0",
+                "sdPublisher": {"@id": "#publisher"},
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Test crate",
+                "hasPart": [{"@id": entity_id}],
+            },
+            {"@id": entity_id, "@type": entity_type},
+            {"@id": "#publisher", "@type": "Organization", "name": "Test publisher"},
+        ],
+    }
+    with ZipFile(path, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("test.eln/ro-crate-metadata.json", json.dumps(metadata))
+
 
 class Test_2(unittest.TestCase):
     """
@@ -13,3 +45,17 @@ class Test_2(unittest.TestCase):
         main function
         """
         generalizedTest(checkParamMetadataJson, 'params_metadata_json')
+
+    def test_array_types_are_checked(self):
+        """Dataset and File rules also apply when @type is an array."""
+        cases = [
+            ("dataset.eln", "data/", ["Dataset", "Message"]),
+            ("file.eln", "data.txt", ["File", "DigitalDocument"]),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            for filename, entity_id, entity_type in cases:
+                with self.subTest(entity_type=entity_type):
+                    path = Path(directory) / filename
+                    write_test_eln(path, entity_id, entity_type)
+                    success, _ = checkParamMetadataJson(path)
+                    self.assertFalse(success)


### PR DESCRIPTION
## Summary

- apply Dataset and File parameter checks when `@type` is either a string or an array
- add regression cases for `['Dataset', 'Message']` and `['File', 'DigitalDocument']`

## Why

The specification allows nodes to have more than one type, represented as an array. The parameter checker compared `@type` only to scalar strings, so an array-valued Dataset or File could bypass the same checks that run for its scalar equivalent. In the reproducer, a Dataset without `name` failed with `"@type": "Dataset"` but incorrectly passed with `"@type": ["Dataset", "Message"]`.

## Validation

- `python -m pytest tests/test_01_params_metadata_json.py -q` (`2 passed`)
- `python -m pytest -q` (`6 passed`)
- `ruff check --select E,F --ignore E501 tests/checks.py tests/test_01_params_metadata_json.py`
- `python -m compileall -q tests tools`
