### PR TITLE
Clarify child Dataset relationships

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -114,7 +114,36 @@ Subsequently, all the remaining nodes are assigned a `@type` of either `Dataset`
 If a Dataset node has additional files, they should be listed in its `hasPart` property and can be referenced through their `@id`.
 All nodes with `@type: Dataset` SHOULD include `name`, `author` properties. Furthermore, other properties of `Dataset`, such as `identifier`, `dateCreated`, `dateModified`, `text`, `keywords`, `comment` MAY also be added.
 
-If a Dataset references other Datasets (_e.g._ a parent experiment with child experiments), they must also be present in the `hasPart` of `./` if they are meant to be imported. A Dataset MUST not contain other Datasets in its `hasPart` section.
+If a Dataset references child Datasets (_e.g._ a parent experiment with child experiments), it SHOULD list them in its `hasPart` section. Each child Dataset that is meant to be imported MUST also be listed directly in the `hasPart` of `./`; a reference from its parent alone does not mark it for import.
+
+For example, both the parent and child experiments below are meant to be imported, while the parent's `hasPart` also records their relationship:
+
+```json
+{
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "hasPart": [
+        { "@id": "./parent/" },
+        { "@id": "./child/" }
+      ]
+    },
+    {
+      "@id": "./parent/",
+      "@type": "Dataset",
+      "hasPart": [
+        { "@id": "./child/" }
+      ]
+    },
+    {
+      "@id": "./child/",
+      "@type": "Dataset",
+      "hasPart": []
+    }
+  ]
+}
+```
 
 All nodes with `@type: File` SHOULD include `name`, `encodingFormat`, `contentSize` properties. Furthermore, other properties of `File`, such as `description`, `sha256`, `author`, `identifier`, `dateCreated`, `dateModified`, `text` MAY also be added.
 


### PR DESCRIPTION
## What changed

- replace the contradictory prohibition on child `Dataset` references with the relationship described in issue #116
- distinguish a parent/child relationship from the root `./` import list
- add a minimal JSON-LD example showing a parent and child that are both selected for import

## Why

The current specification first says that child datasets can be referenced and must also appear in the root import list, then says that datasets must not contain other datasets in `hasPart`. This makes the intended parent/child representation impossible to follow. The new wording keeps both roles explicit: nested `hasPart` records the relationship, while direct root membership marks a dataset for import.

Closes #116.

## Validation

- `git diff --check`
- `python -m pytest` — 6 passed
