### PR TITLE
Validate the .eln single-root archive structure

### DIFF
--- a/tests/checks.py
+++ b/tests/checks.py
@@ -1,7 +1,7 @@
 import json
 import traceback
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 from jsonschema import Draft202012Validator
@@ -9,6 +9,49 @@ from rocrate.rocrate import ROCrate
 from rocrate_validator import services, models
 
 METADATA_FILE = 'ro-crate-metadata.json'
+
+
+def checkArchiveStructure(fileName):
+    """Check that an .eln ZIP contains exactly one root folder.
+
+    Args:
+        fileName: path to .eln file
+    Returns:
+        success: bool if check was successful
+        log: string with log information
+    """
+    with ZipFile(fileName, 'r', compression=ZIP_DEFLATED) as elnFile:
+        entries_outside_root = set()
+        root_folders = set()
+        for entry in elnFile.infolist():
+            path = PurePosixPath(entry.filename)
+            if (
+                    not path.parts
+                    or path.is_absolute()
+                    or '..' in path.parts
+                    or (len(path.parts) == 1 and not entry.is_dir())
+            ):
+                entries_outside_root.add(entry.filename)
+            else:
+                root_folders.add(path.parts[0])
+
+        log = ''
+        if entries_outside_root:
+            entries = ', '.join(
+                repr(path) for path in sorted(entries_outside_root)
+            )
+            log += (
+                '**ERROR: .eln archive entries must be stored inside the root '
+                f'folder: {entries}\n'
+            )
+        if len(root_folders) != 1:
+            folders = ', '.join(repr(path) for path in sorted(root_folders))
+            log += (
+                '**ERROR: .eln archive must contain exactly one root folder; '
+                f'found {len(root_folders)}: {folders}\n'
+            )
+        return not log, log
+
 
 def checkPypiRocrate(fileName, verbose=False):
     """ Check if file is a valid ro-crate according to pypi rocrate package

--- a/tests/test_04_archive_structure.py
+++ b/tests/test_04_archive_structure.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+"""Validate the outer archive structure required by the .eln specification."""
+import tempfile
+import unittest
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from checks import checkArchiveStructure
+from test_00_pypi_rocrate import generalizedTest
+
+
+def write_test_archive(path, entries):
+    """Write a small ZIP fixture with the given entry names."""
+    with ZipFile(path, 'w', compression=ZIP_DEFLATED) as archive:
+        for entry in entries:
+            archive.writestr(entry, '' if entry.endswith('/') else '{}')
+
+
+class TestArchiveStructure(unittest.TestCase):
+    """Test the .eln single-root-folder requirement."""
+
+    def test_main(self):
+        """Validate the structure of all repository examples."""
+        generalizedTest(checkArchiveStructure, 'archive_structure')
+
+    def test_accepts_single_root_folder(self):
+        """A directory entry is optional when every file has the same root."""
+        cases = [
+            ['crate/ro-crate-metadata.json', 'crate/data/value.txt'],
+            ['crate/', 'crate/ro-crate-metadata.json'],
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            for index, entries in enumerate(cases):
+                with self.subTest(entries=entries):
+                    path = Path(directory) / f'valid-{index}.eln'
+                    write_test_archive(path, entries)
+                    self.assertEqual(checkArchiveStructure(path), (True, ''))
+
+    def test_rejects_root_level_file(self):
+        """Files alongside the root folder violate the archive layout."""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'root-file.eln'
+            write_test_archive(path, [
+                'crate/ro-crate-metadata.json',
+                'unexpected-root.txt',
+            ])
+            self.assertEqual(checkArchiveStructure(path), (
+                False,
+                '**ERROR: .eln archive entries must be stored inside the root '
+                "folder: 'unexpected-root.txt'\n",
+            ))
+
+    def test_rejects_multiple_root_folders(self):
+        """Two top-level folders are not a single .eln RO-Crate."""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'multiple-roots.eln'
+            write_test_archive(path, [
+                'first/ro-crate-metadata.json',
+                'second/data.txt',
+            ])
+            self.assertEqual(checkArchiveStructure(path), (
+                False,
+                '**ERROR: .eln archive must contain exactly one root folder; '
+                "found 2: 'first', 'second'\n",
+            ))

--- a/tests/test_99_logging.py
+++ b/tests/test_99_logging.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import json
 import unittest
 
-COLUMNS = ['pypi_rocrate','validator','schema','params_metadata_json']
+COLUMNS = ['archive_structure','pypi_rocrate','validator','schema','params_metadata_json']
 HEADER  = "## Results of verification\nautomatically created\n\n"
 
 
@@ -31,6 +31,7 @@ class Test_2(unittest.TestCase):
                     resultStr   = ' | '.join([':white_check_mark:' if col in result and result[col] else ':x:' for col in COLUMNS])
                     output.write(f'| {software} | {individualFileName} | {resultStr} |\n')
                 output.write("\n\nDefinition of tests\n")
+                output.write("- **archive_structure**: tests if the .eln ZIP contains exactly one root folder.\n")
                 output.write("- **pypi_rocrate**: tests if eln-file can be opened by pypi's rocrate; if eln file can be easily opened by that library.\n")
                 output.write("- **validator**: tests if the ro-crate conventions fulfilled using pypi's roc-validator.\n")
                 output.write("- **schema**: tests if the conventions of the ELN-consortium are fulfilled using a schema description.\n")


### PR DESCRIPTION
## Summary

- add an explicit `.eln` archive-structure check for the specification's single-root-folder requirement
- accept archives whether or not the ZIP contains an explicit directory entry, as long as every entry belongs to the same root folder
- reject root-level files, multiple root folders, and paths that can escape or bypass the root
- include the new result in the generated verification summary

## Problem

The specification requires a single folder at the ZIP root, but the existing checks only inspect or extract the first matching RO-Crate. An archive can therefore contain a valid crate folder plus an unrelated root-level file and still pass all four checks.

This was reproduced from the current OpenSemanticLab example by adding `unexpected-root.txt` beside its `MinimalExample` folder. On `master` at `19028dd`, PyPI RO-Crate, validator, parameter, and schema checks all returned success for the resulting two-root archive (SHA-256 `e9f329deb4e592c1b2ed9e6b7215d953468423eaf4264f28280184c749efbcc8`).

## Verification

Local verification on Windows with Python 3.13.1 and the pinned `tests/requirements.txt` dependencies:

- `python -m pytest -q --tb=short tests/test_04_archive_structure.py` — 4 passed
- all 11 repository `.eln` examples, including the three `SKIP_CI` examples, passed the new archive-structure check
- `python -m pytest -q --tb=short` — 10 passed / 17 existing dependency warnings
- upstream baseline at `19028dd` with the same environment — 6 passed / 17 warnings
- `git diff --check` — passed

The exact previously accepted negative archive now returns:

```text
False, **ERROR: .eln archive entries must be stored inside the root folder: 'unexpected-root.txt'
```

Not run locally: the documentation build, because no documentation source changed. No separate linter is configured in this repository. These are local results only; they do not claim that GitHub Actions has passed.

Related to #67.
